### PR TITLE
mc-text should be hideable

### DIFF
--- a/src/mc-text.js
+++ b/src/mc-text.js
@@ -7,6 +7,7 @@ export default class McText extends BodyComponent {
 
   static allowedAttributes = {
     'mc:edit': 'string',
+    'mc:hideable': 'boolean',
     align: 'enum(left,right,center)',
     'background-color': 'color',
     color: 'color',


### PR DESCRIPTION
According to https://templates.mailchimp.com/getting-started/template-language/

> Use mc:hideable on any HTML element